### PR TITLE
Separate out PR and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,14 +1,18 @@
-name: demo-app-deployment
+name: deploy
 
 on:
   push:
+    branches:
+      - dev
+      - staging
+      - prod
 
 env:
   IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
   RODE_HOST: rode.rode-demo.svc.cluster.local:50051
 
 jobs:
-  evaluate:
+  deploy:
     runs-on:
       - self-hosted
       - rode-runners-prod
@@ -32,17 +36,6 @@ jobs:
           resourceUri: ${{ steps.get.outputs.resourceUri }}
           rodeHost: ${{ env.RODE_HOST }}
           rodeInsecure: true
-
-  deploy:
-    if: ${{ contains(fromJson('["refs/heads/dev", "refs/heads/staging", "refs/heads/prod"]'), github.ref) }}
-    needs:
-      - evaluate
-    runs-on:
-      - self-hosted
-      - rode-runners-prod
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
 
       - name: Install Helm
         run: curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
       - prod
 
 env:
-  IMAGE: foo #harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
+  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
   RODE_HOST: rode.rode-demo.svc.cluster.local:50051
 
 jobs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
       - prod
 
 env:
-  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
+  IMAGE: foo #harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
   RODE_HOST: rode.rode-demo.svc.cluster.local:50051
 
 jobs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,38 @@
+name: pr
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - prod
+
+env:
+  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
+  RODE_HOST: rode.rode-demo.svc.cluster.local:50051
+
+jobs:
+  evaluate:
+    runs-on:
+      - self-hosted
+      - rode-runners-prod
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Get Resource URI
+        id: get
+        run: |
+          digest=$(awk '/tag/{print $2}' env-values.yaml)
+          resourceUri="${{ env.IMAGE }}@sha256:$digest"
+          echo "::set-output name=resourceUri::$resourceUri"
+
+      - name: Evaluate Policy
+        id: policy
+        uses: rode/evaluate-policy-action@v0.1.0
+        with:
+          enforce: ${{ github.base_ref != 'refs/heads/dev' }} # don't require policy to pass when a PR targets dev
+          policyName: Sample Harbor Policy
+          resourceUri: ${{ steps.get.outputs.resourceUri }}
+          rodeHost: ${{ env.RODE_HOST }}
+          rodeInsecure: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,13 +27,11 @@ jobs:
           resourceUri="${{ env.IMAGE }}@sha256:$digest"
           echo "::set-output name=resourceUri::$resourceUri"
 
-          echo "debug ${{ github.base_ref }}"
-
       - name: Evaluate Policy
         id: policy
         uses: rode/evaluate-policy-action@v0.1.0
         with:
-          enforce: ${{ github.base_ref != 'refs/heads/dev' }} # don't require policy to pass when a PR targets dev
+          enforce: ${{ github.base_ref != 'dev' }} # don't require policy to pass when a PR targets dev
           policyName: Sample Harbor Policy
           resourceUri: ${{ steps.get.outputs.resourceUri }}
           rodeHost: ${{ env.RODE_HOST }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
       - prod
 
 env:
-  IMAGE: foo #harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
+  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
   RODE_HOST: rode.rode-demo.svc.cluster.local:50051
 
 jobs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,6 +27,8 @@ jobs:
           resourceUri="${{ env.IMAGE }}@sha256:$digest"
           echo "::set-output name=resourceUri::$resourceUri"
 
+          echo "debug ${{ github.base_ref }}"
+
       - name: Evaluate Policy
         id: policy
         uses: rode/evaluate-policy-action@v0.1.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
       - prod
 
 env:
-  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
+  IMAGE: foo #harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
   RODE_HOST: rode.rode-demo.svc.cluster.local:50051
 
 jobs:


### PR DESCRIPTION
Separate workflows for push/pull request events. Prevents triggering a deployment when making PRs to higher environments and fixes enforcement. 