### PR TITLE
Use shared services Rode

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Helm Upgrade
         run: |
-          branchName=${GITHUB_REF##*/}
+          branchName=dev
 
           helm version
           helm upgrade -f env-values.yaml \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,14 +40,13 @@ jobs:
           tokenUrl: ${{ env.OAUTH2_TOKEN_URL }}
 
       - name: Evaluate Resource
-        uses: rode/enforcer-action@v0.3.0
+        uses: rode/enforcer-action@v0.3.2
         with:
           accessToken: ${{ steps.token.outputs.accessToken }}
           enforce: ${{ github.ref != 'refs/heads/dev' }} # don't require policy to pass in dev
           policyGroup: rode-demo
           resourceUri: ${{ steps.get.outputs.resourceUri }}
           rodeHost: ${{ env.RODE_HOST }}
-          rodeInsecure: true
 
       - name: Install Helm
         run: curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,9 +8,9 @@ on:
       - prod
 
 env:
-  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
-  RODE_HOST: rode.rode-demo.svc.cluster.local:50051
-  OAUTH2_TOKEN_URL: 'https://keycloak.internal.lead.prod.liatr.io/auth/realms/rode-demo/protocol/openid-connect/token'
+  IMAGE: harbor.services.liatr.io/liatrio/rode-demo-node-app
+  RODE_HOST: rode-grpc.services.liatr.io:443
+  OAUTH2_TOKEN_URL: 'https://keycloak.services.liatr.io/auth/realms/liatrio/protocol/openid-connect/token'
   OAUTH2_CLIENT_ID: rode-enforcer
 
 jobs:
@@ -18,6 +18,7 @@ jobs:
     runs-on:
       - self-hosted
       - rode-runners-prod
+    environment: liatrio-sharedsvc
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,7 @@ on:
       - dev
       - staging
       - prod
+      - sharedsvc
 
 env:
   IMAGE: harbor.services.liatr.io/liatrio/rode-demo-node-app

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,6 @@ on:
       - dev
       - staging
       - prod
-      - sharedsvc
 
 env:
   IMAGE: harbor.services.liatr.io/liatrio/rode-demo-node-app
@@ -53,7 +52,7 @@ jobs:
 
       - name: Helm Upgrade
         run: |
-          branchName=dev
+          branchName=${GITHUB_REF##*/}
 
           helm version
           helm upgrade -f env-values.yaml \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,9 +8,9 @@ on:
       - prod
 
 env:
-  IMAGE: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
-  RODE_HOST: rode.rode-demo.svc.cluster.local:50051
-  OAUTH2_TOKEN_URL: 'https://keycloak.internal.lead.prod.liatr.io/auth/realms/rode-demo/protocol/openid-connect/token'
+  IMAGE: harbor.services.liatr.io/liatrio/rode-demo-node-app
+  RODE_HOST: rode-grpc.services.liatr.io:443
+  OAUTH2_TOKEN_URL: 'https://keycloak.services.liatr.io/auth/realms/liatrio/protocol/openid-connect/token'
   OAUTH2_CLIENT_ID: rode-enforcer
 
 jobs:
@@ -18,6 +18,7 @@ jobs:
     runs-on:
       - self-hosted
       - rode-runners-prod
+    environment: liatrio-sharedsvc
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
           tokenUrl: ${{ env.OAUTH2_TOKEN_URL }}
 
       - name: Evaluate Resource
-        uses: rode/enforcer-action@v0.3.0
+        uses: rode/enforcer-action@v0.3.2
         with:
           accessToken: ${{ steps.token.outputs.accessToken }}
           enforce: ${{ github.base_ref != 'dev' }} # don't require policy to pass when a PR targets dev
@@ -47,4 +47,3 @@ jobs:
           policyGroup: rode-demo
           resourceUri: ${{ steps.get.outputs.resourceUri }}
           rodeHost: ${{ env.RODE_HOST }}
-          rodeInsecure: true

--- a/charts/demo-app/values.yaml
+++ b/charts/demo-app/values.yaml
@@ -5,13 +5,12 @@
 replicaCount: 1
 
 image:
-  repository: harbor.internal.lead.prod.liatr.io/rode-demo/rode-demo-node-app
+  repository: harbor.services.liatr.io/liatrio/rode-demo-node-app
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets:
-  - name: harbor
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
We're still deploying to the LEAD environment, but using the Rode installation in shared services. 